### PR TITLE
implementação do 'unauthorizedResponse'para não duplicar códigos

### DIFF
--- a/src/controllers/User.controller.ts
+++ b/src/controllers/User.controller.ts
@@ -180,4 +180,3 @@ export const loginUser = async (req: Request, res: Response) => {
       .json({ message: "error at login user", error: error });
   }
 };
- 

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,6 +1,16 @@
 import { NextFunction, Request, Response } from "express";
 import { Session } from "../models/session.model";
 
+// Configuração do tempo de expiração em milissegundos
+const SESSION_EXPIRATION_TIME = process.env.SESSION_EXPIRATION_TIME || 120000;
+
+// função de resposta de erro. 'unauthorizedResponse' => reduz a duplicação de códigos.
+const unauthorizedResponse = (res: Response, message: string) => {
+  return res.status(401).json({
+    message:"Você não está autorizado a fazer isso"
+  });
+};
+// Middleware de autenticação
 export const authenticationMiddleware = async (
   req: Request,
   res: Response,
@@ -8,41 +18,32 @@ export const authenticationMiddleware = async (
 ) => {
   const userToken = req.headers.token;
 
-  if(!userToken){
-    return res.status(401).json({
-        message: "Você não está autorizado a fazer isso "
-    })
+  if (!userToken) {
+    return unauthorizedResponse(res, "Você não está autorizado a fazer isso");
   }
 
+// Busca a sessão do usuário
   const userSession = await Session.findOne({
     where: { token: userToken, active: true },
   });
 
-  if(!userSession){
-      return res.status(401).json({
-          message: "Você não está autorizado a fazer isso"
-        })
-    }
-    
-    // implementation here
-    const expiredSession = userSession.createdAt
-    const dateSessionMs = expiredSession.getTime()
-    
-    const dateNow = new Date()
-    const dateNowMs = dateNow.getTime()
-     
-     
-    const diferencDate: number = dateNowMs - dateSessionMs
+  if (!userSession) {
+    return unauthorizedResponse(res, "Você não está autorizado a fazer isso");
+  }
 
-    if(diferencDate > 120000){
-        userSession.update({active: false})
-        userSession.save()
-        return res.status(401).json({
-            message: "Você não está autorizado a fazer isso"
-          })
-    }
-    
-    
+// Verifica se a sessão expirou
+
+  const expiredSession = userSession.createdAt;
+  const dateSessionMs = expiredSession.getTime();
+  const dateNow = new Date();
+  const dateNowMs = dateNow.getTime();
+
+  const diferencDate = dateNowMs - dateSessionMs
+
+  if (diferencDate > parseInt('SESSION_EXPIRATION_TIME')) {
+    await userSession.update({ active: false });
+    return unauthorizedResponse(res, "Você não está autorizado a fazer isso");
+  }
+
   next();
-    
 };


### PR DESCRIPTION
Criei uma constante para armazenar o tempo de sessão em milissegundos. Também coloquei uma função que centraliza a lógica de resposta para mensagens de erro 401, reduzindo a duplicação de código.
